### PR TITLE
Ability to configure TTL

### DIFF
--- a/lib/twingly/url_cache.rb
+++ b/lib/twingly/url_cache.rb
@@ -5,17 +5,19 @@ require "retryable"
 
 module Twingly
   class UrlCache
-    TTL = nil
+    attr_reader :ttl
+
     CACHE_VALUE = ""
 
-    def initialize
+    def initialize(ttl: 0)
       @cache = Dalli::Client.new(servers, options)
+      @ttl = ttl
     end
 
     def cache!(url)
       key = key_for(url)
       Retryable.retryable(tries: 3, on: Dalli::RingError) do
-        !!@cache.set(key, CACHE_VALUE, TTL, raw: true)
+        !!@cache.set(key, CACHE_VALUE, ttl, raw: true)
       end
     end
 

--- a/spec/lib/url_cache_spec.rb
+++ b/spec/lib/url_cache_spec.rb
@@ -4,10 +4,25 @@ describe Twingly::UrlCache do
 
   subject(:cache) { described_class.new }
 
+  it { is_expected.to respond_to(:ttl) }
   it { is_expected.to respond_to(:cache!) }
   it { is_expected.to respond_to(:cached?) }
 
   let(:url) { "http://blog.twingly.com/#{SecureRandom.hex}" }
+
+  describe "#ttl" do
+    subject { cache.ttl }
+
+    context "with default ttl (no expire)" do
+      it { is_expected.to be(0) }
+    end
+
+    context "when set to custom value" do
+      let(:ttl) { 3 }
+      subject { described_class.new(ttl: ttl).ttl }
+      it { is_expected.to be(ttl) }
+    end
+  end
 
   describe "#cache!" do
     subject { cache.cache!(url) }
@@ -26,6 +41,20 @@ describe Twingly::UrlCache do
       subject { cache.cached?(url) }
 
       it { is_expected.to be(true) }
+    end
+
+    context "when expired" do
+      let(:ttl) { 1 }
+      let(:cache) { described_class.new(ttl: ttl) }
+
+      before do
+        cache.cache!(url)
+        sleep ttl * 2
+      end
+
+      subject { cache.cached?(url) }
+
+      it { is_expected.to be(false) }
     end
   end
 end


### PR DESCRIPTION
Previously we used nil by default, but 0 is what Dalli uses to describe "no expire". Dalli runs `#to_i` on the ttl before using it.
