### PR TITLE
Raise our own errors instead of Dalli errors

### DIFF
--- a/lib/twingly/url_cache.rb
+++ b/lib/twingly/url_cache.rb
@@ -12,14 +12,9 @@ module Twingly
 
     CACHE_VALUE = ""
 
-    def initialize(ttl: 0)
-      @cache = retry_transient_exceptions do
-        with_exception_class_conversion do
-          Dalli::Client.new(servers, options)
-        end
-      end
-
-      @ttl = ttl
+    def initialize(ttl: 0, cache: default_cache)
+      @ttl   = ttl
+      @cache = cache
     end
 
     def cache!(url)
@@ -46,6 +41,14 @@ module Twingly
 
     def key_for(url)
       Digest::MD5.digest(url)
+    end
+
+    def default_cache
+      retry_transient_exceptions do
+        with_exception_class_conversion do
+          Dalli::Client.new(servers, options)
+        end
+      end
     end
 
     def options

--- a/lib/twingly/url_cache.rb
+++ b/lib/twingly/url_cache.rb
@@ -14,7 +14,7 @@ module Twingly
 
     def initialize(ttl: 0)
       @cache = retry_transient_exceptions do
-        handle_memcached_exceptions do
+        with_exception_class_conversion do
           Dalli::Client.new(servers, options)
         end
       end
@@ -26,7 +26,7 @@ module Twingly
       key = key_for(url)
 
       retry_transient_exceptions do
-        handle_memcached_exceptions do
+        with_exception_class_conversion do
           !!@cache.set(key, CACHE_VALUE, ttl, raw: true)
         end
       end
@@ -36,7 +36,7 @@ module Twingly
       key = key_for(url)
 
       retry_transient_exceptions do
-        handle_memcached_exceptions do
+        with_exception_class_conversion do
           @cache.get(key, raw: true) == CACHE_VALUE
         end
       end
@@ -62,7 +62,7 @@ module Twingly
       ENV.fetch("MEMCACHIER_SERVERS") { "localhost" }.split(",")
     end
 
-    def handle_memcached_exceptions
+    def with_exception_class_conversion
       yield
     rescue Dalli::RingError => error
       raise ServerError, error.message

--- a/lib/twingly/url_cache.rb
+++ b/lib/twingly/url_cache.rb
@@ -24,9 +24,7 @@ module Twingly
       key = key_for(url)
 
       with_memcached_exception_handling do
-        Retryable.retryable(tries: 3, on: Dalli::RingError) do
-          !!@cache.set(key, CACHE_VALUE, ttl, raw: true)
-        end
+        !!@cache.set(key, CACHE_VALUE, ttl, raw: true)
       end
     end
 
@@ -34,9 +32,7 @@ module Twingly
       key = key_for(url)
 
       with_memcached_exception_handling do
-        Retryable.retryable(tries: 3, on: Dalli::RingError) do
-          @cache.get(key, raw: true) == CACHE_VALUE
-        end
+        @cache.get(key, raw: true) == CACHE_VALUE
       end
     end
 
@@ -60,8 +56,8 @@ module Twingly
       ENV.fetch("MEMCACHIER_SERVERS") { "localhost" }.split(",")
     end
 
-    def with_memcached_exception_handling
-      yield
+    def with_memcached_exception_handling(&block)
+      Retryable.retryable(tries: 3, on: Dalli::RingError, &block)
     rescue Dalli::RingError => error
       raise ServerError, error.message
     rescue Dalli::DalliError => error

--- a/spec/lib/url_cache_spec.rb
+++ b/spec/lib/url_cache_spec.rb
@@ -41,10 +41,11 @@ describe Twingly::UrlCache do
       context "when a Dalli::RingError is raised" do
         let(:dalli_error_class) { Dalli::RingError }
 
-        it "retries a few times" do
+        number_of_tries = 3
+        it "tries #{number_of_tries} times" do
           expect(dalli_client)
             .to receive(dalli_method_name)
-            .exactly(3).times
+            .exactly(number_of_tries).times
 
           begin
             subject

--- a/spec/lib/url_cache_spec.rb
+++ b/spec/lib/url_cache_spec.rb
@@ -38,6 +38,18 @@ describe Twingly::UrlCache do
       context "when a Dalli::RingError is raised" do
         let(:dalli_error_class) { Dalli::RingError }
 
+        it "should retry a few times" do
+          expect_any_instance_of(Dalli::Client)
+            .to receive(dalli_method_name)
+            .exactly(3).times
+
+          begin
+            subject
+          rescue Twingly::UrlCache::ServerError
+            # NOOP
+          end
+        end
+
         it "should raise a UrlCache::ServerError" do
           expect { subject }.to raise_error(Twingly::UrlCache::ServerError,
                                             error_message)

--- a/spec/lib/url_cache_spec.rb
+++ b/spec/lib/url_cache_spec.rb
@@ -24,28 +24,62 @@ describe Twingly::UrlCache do
     end
   end
 
+  shared_examples "memcached exceptions" do |dalli_method_name|
+    describe "memcached exception handling" do
+      let(:error_message) { "An error has occured!" }
+      let(:dalli_error) { dalli_error_class.new(error_message) }
+
+      before do
+        allow_any_instance_of(Dalli::Client)
+          .to receive(dalli_method_name)
+          .and_raise(dalli_error)
+      end
+
+      context "when a Dalli::RingError is raised" do
+        let(:dalli_error_class) { Dalli::RingError }
+
+        it "should raise a UrlCache::ServerError" do
+          expect { subject }.to raise_error(Twingly::UrlCache::ServerError,
+                                            error_message)
+        end
+      end
+
+      context "when a Dalli::DalliError is raised" do
+        let(:dalli_error_class) { Dalli::DalliError }
+
+        it "should raise a UrlCache::Error" do
+          expect { subject }.to raise_error(Twingly::UrlCache::Error,
+                                            error_message)
+        end
+      end
+    end
+  end
+
   describe "#cache!" do
+    subject(:cache!) { cache.cache!(url) }
+
     context "when run once" do
-      subject { cache.cache!(url) }
       it { is_expected.to be(true) }
     end
 
     context "when run multiple times on same key" do
-      subject { 14.times.map { cache.cache!(url) } }
+      subject { 14.times.map { cache! } }
+
       it { is_expected.to all(be(true)) }
     end
+
+    include_examples "memcached exceptions", :set
   end
 
   describe "#cached?" do
-    context "when uncached" do
-      subject { cache.cached?(url) }
+    subject { cache.cached?(url) }
 
+    context "when uncached" do
       it { is_expected.to be(false) }
     end
 
     context "when cached" do
       before { cache.cache!(url) }
-      subject { cache.cached?(url) }
 
       it { is_expected.to be(true) }
     end
@@ -59,9 +93,9 @@ describe Twingly::UrlCache do
         sleep ttl * 2
       end
 
-      subject { cache.cached?(url) }
-
       it { is_expected.to be(false) }
     end
+
+    include_examples "memcached exceptions", :get
   end
 end

--- a/spec/lib/url_cache_spec.rb
+++ b/spec/lib/url_cache_spec.rb
@@ -41,7 +41,7 @@ describe Twingly::UrlCache do
       context "when a Dalli::RingError is raised" do
         let(:dalli_error_class) { Dalli::RingError }
 
-        it "should retry a few times" do
+        it "retries a few times" do
           expect(dalli_client)
             .to receive(dalli_method_name)
             .exactly(3).times
@@ -53,7 +53,7 @@ describe Twingly::UrlCache do
           end
         end
 
-        it "should raise a UrlCache::ServerError" do
+        it "raises a UrlCache::ServerError" do
           expect { subject }.to raise_error(Twingly::UrlCache::ServerError,
                                             error_message)
         end
@@ -62,7 +62,7 @@ describe Twingly::UrlCache do
       context "when a Dalli::DalliError is raised" do
         let(:dalli_error_class) { Dalli::DalliError }
 
-        it "should raise a UrlCache::Error" do
+        it "raises a UrlCache::Error" do
           expect { subject }.to raise_error(Twingly::UrlCache::Error,
                                             error_message)
         end


### PR DESCRIPTION
#8 has been open for quite a while, thought I give it a try.

This works, but the tests uses "allow_any_instance_of" which isn't that nice. Any improvement ideas welcome :)

close #8

### Todo

- [x] Add specs for retries, there were none before ([f18173f](/twingly/twingly-url_cache/pull/9/commits/f18173fe1b7074da1e1d6b5a3c8e71640018ca7d))