### PR TITLE
Newer Ruby on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: ruby
 rvm:
   - 2.4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 rvm:
-  - 2.4.7
-  - 2.6.4
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
 services:
   - memcached
 notifications:


### PR DESCRIPTION
Added 2.5.7 since we test that for our other projects (twingly-amqp, twingly-url, etc.).

Also added `dist: bionic` just so we have control over which distribution we test on. We have this defined in most of our other projects.