### PR TITLE
Test with latest Rubies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6.7, 2.7.3, 3.0.1]
+        ruby: [2.7.6, 3.0.4, 3.1.2]
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Drop Ruby 2.6 since it's EOL since 2022-04-12.