### PR TITLE
Update Dalli to 3.2.3

### DIFF
--- a/twingly-url_cache.gemspec
+++ b/twingly-url_cache.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.glob("{lib}/**/*") + %w(README.md)
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "dalli", "~> 2.7"
+  spec.add_dependency "dalli", "~> 3.2.3"
   spec.add_dependency "retryable", "~> 2.0"
 
   spec.add_development_dependency "rake", "~> 12"


### PR DESCRIPTION
> A vulnerability was found in Dalli. Affected is the function self.meta_set of the file lib/dalli/protocol/meta/request_formatter.rb of the component Meta Protocol Handler. The manipulation leads to injection. The exploit has been disclosed to the public and may be used. The name of the patch is 48d594dae55934476fec61789e7a7c3700e0f50d. It is recommended to apply a patch to fix this issue.