### PR TITLE
Run CI on latest Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7.6, 3.0.4, 3.1.2]
+        ruby: [3.1.6, 3.2.4, 3.3.2]
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Ruby 2.7 and 3.0 have reached EOL.